### PR TITLE
fix: normalize RISC-V target arch in Cargo cfgs

### DIFF
--- a/rs/private/cfg_parser.bzl
+++ b/rs/private/cfg_parser.bzl
@@ -150,6 +150,15 @@ def _normalize_os(os_raw):
         return "macos"
     return os_raw
 
+def _normalize_arch(arch_raw):
+    # RISC-V target triples encode the enabled ISA extensions in their first
+    # component, while Rust's cfg(target_arch) exposes only the register width.
+    if arch_raw.startswith("riscv32"):
+        return "riscv32"
+    if arch_raw.startswith("riscv64"):
+        return "riscv64"
+    return arch_raw
+
 def _family_for_os(os_name):
     if os_name == "windows":
         return "windows"
@@ -211,7 +220,7 @@ def _target_has_feature(ctx, feature):
 
 def triple_to_cfg_attrs(triple):
     parts = triple.split("-")
-    arch_part = _get(parts, 0, "")
+    arch_part = _normalize_arch(_get(parts, 0, ""))
     vendor_part = _get(parts, 1, "unknown")
     os_raw_part = _get(parts, 2, "none")
     env_part = "-".join(parts[3:])

--- a/rs/private/cfg_parser_test.bzl
+++ b/rs/private/cfg_parser_test.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load(":cfg_parser.bzl", "cfg_matches", "cfg_matches_expr_for_triples", "triple_to_cfg_attrs", "cfg_matches_expr_for_cfg_attrs")
+load(":cfg_parser.bzl", "cfg_matches", "cfg_matches_expr_for_cfg_attrs", "cfg_matches_expr_for_triples", "triple_to_cfg_attrs")
 
 def _cfg(expr):
     return "cfg(%s)" % expr
@@ -14,6 +14,8 @@ def _cfg_parser_smoke_test_impl(ctx):
     win_gnu = "x86_64-pc-windows-gnu"
     win_gnullvm = "aarch64-pc-windows-gnullvm"
     wasm = "wasm32-unknown-unknown"
+    riscv32imac = "riscv32imac-unknown-none-elf"
+    riscv64gc = "riscv64gc-unknown-linux-musl"
 
     # MacOS facts facts
     asserts.true(env, cfg_matches(_cfg("unix"), mac))
@@ -47,6 +49,15 @@ def _cfg_parser_smoke_test_impl(ctx):
     asserts.true(env, cfg_matches(_cfg('target_family = "wasm"'), wasm))
     asserts.true(env, cfg_matches(_cfg('target_pointer_width = "32"'), wasm))
 
+    # RISC-V triples include ISA extensions in the architecture component, but
+    # Rust exposes the register width through cfg(target_arch).
+    asserts.true(env, cfg_matches(_cfg('target_arch = "riscv32"'), riscv32imac))
+    asserts.true(env, cfg_matches(_cfg('target_pointer_width = "32"'), riscv32imac))
+    asserts.false(env, cfg_matches(_cfg('target_arch = "riscv32imac"'), riscv32imac))
+    asserts.true(env, cfg_matches(_cfg('target_arch = "riscv64"'), riscv64gc))
+    asserts.true(env, cfg_matches(_cfg('target_pointer_width = "64"'), riscv64gc))
+    asserts.false(env, cfg_matches(_cfg('target_arch = "riscv64gc"'), riscv64gc))
+
     # Combinators
     asserts.false(env, cfg_matches(_cfg("any()"), mac))
     asserts.true(env, cfg_matches(_cfg("not(any())"), mac))
@@ -63,15 +74,16 @@ def _cfg_parser_smoke_test_impl(ctx):
     asserts.true(env, cfg_matches(_cfg('target_feature = "sse2"'), linux_gnu))
     asserts.false(env, cfg_matches(_cfg('target_feature = "sse2"'), mac))
 
-    triples = [mac, linux_gnu, linux_musl, win, win_gnu, win_gnullvm, wasm]
+    triples = [mac, linux_gnu, linux_musl, win, win_gnu, win_gnullvm, wasm, riscv32imac, riscv64gc]
 
     results = cfg_matches_expr_for_triples(_cfg('all(unix, any(target_env = "gnu", target_env = "musl"))'), triples)
-    asserts.equals(env, results.matches, [linux_gnu, linux_musl])
+    asserts.equals(env, results.matches, [linux_gnu, linux_musl, riscv64gc])
 
     results = cfg_matches_expr_for_triples(
         _cfg('any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86")'),
-        triples)
-    asserts.equals(env, results.matches, triples[:-1])
+        triples,
+    )
+    asserts.equals(env, results.matches, [mac, linux_gnu, linux_musl, win, win_gnu, win_gnullvm])
 
     # Cargo dependencies can target a specific triple instead of a cfg expression.
     results = cfg_matches_expr_for_triples(win_gnullvm, triples)


### PR DESCRIPTION
## Summary

- normalize ISA-bearing RISC-V triple architecture components to Rust cfg target_arch values
- cover both RV32IMAC and RV64GC
- use explicit expected architecture matches in the cfg-parser test

RISC-V target triples include ISA extensions in their architecture component, such as  and . Rust's  cfg instead exposes the canonical values  and .

Without this normalization, Cargo dependencies gated on the standard RISC-V  values can be omitted even though the selected target is RISC-V.

## Validation

- [WARNING] top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
buildifier...............................................................Failed
- hook id: buildifier
- files were modified by this hook
- //rs/private:cfg_parser_tests_test_0                            (cached) PASSED in 0.4s

Executed 0 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
- //rs/private:all_crate_deps_tests_test_0                        (cached) PASSED in 0.3s
//rs/private:all_crate_deps_tests_test_1                        (cached) PASSED in 0.8s
//rs/private:all_crate_deps_tests_test_2                        (cached) PASSED in 1.1s
//rs/private:all_crate_deps_tests_test_3                        (cached) PASSED in 0.9s
//rs/private:bindgen_tests_test_0                               (cached) PASSED in 0.7s
//rs/private:bindgen_tests_test_1                               (cached) PASSED in 0.4s
//rs/private:bindgen_tests_test_2                               (cached) PASSED in 0.9s
//rs/private:bpf_linker_repository_name_test                    (cached) PASSED in 0.6s
//rs/private:cargo_toml_is_proc_macro_test                      (cached) PASSED in 0.7s
//rs/private:cargo_workspace_graph_tests_test_0                 (cached) PASSED in 0.5s
//rs/private:cargo_workspace_graph_tests_test_1                 (cached) PASSED in 0.8s
//rs/private:cargo_workspace_graph_tests_test_2                 (cached) PASSED in 0.8s
//rs/private:cargo_workspace_graph_tests_test_3                 (cached) PASSED in 0.4s
//rs/private:cargo_workspace_graph_tests_test_4                 (cached) PASSED in 1.3s
//rs/private:cargo_workspace_graph_tests_test_5                 (cached) PASSED in 1.7s
//rs/private:cargo_workspace_graph_tests_test_6                 (cached) PASSED in 1.3s
//rs/private:cfg_parser_tests_test_0                            (cached) PASSED in 0.4s
//rs/private:lint_flags_tests_test_0                            (cached) PASSED in 0.8s
//rs/private:lint_flags_tests_test_1                            (cached) PASSED in 0.4s
//rs/private:lint_flags_tests_test_2                            (cached) PASSED in 0.8s
//rs/private:lint_flags_tests_test_3                            (cached) PASSED in 0.5s
//rs/private:registry_utils_tests_test_0                        (cached) PASSED in 1.5s
//rs/private:registry_utils_tests_test_1                        (cached) PASSED in 0.8s
//rs/private:rust_repository_utils_tests_test_0                 (cached) PASSED in 0.3s
//rs/private:rust_repository_utils_tests_test_1                 (cached) PASSED in 0.5s
//rs/private:rust_repository_utils_tests_test_2                 (cached) PASSED in 0.7s
//rs/private:semver_select_tests_test_0                         (cached) PASSED in 1.7s
//rs/private:semver_select_tests_test_1                         (cached) PASSED in 1.6s
//rs/private:semver_select_tests_test_10                        (cached) PASSED in 0.5s
//rs/private:semver_select_tests_test_11                        (cached) PASSED in 0.9s
//rs/private:semver_select_tests_test_2                         (cached) PASSED in 0.9s
//rs/private:semver_select_tests_test_3                         (cached) PASSED in 0.9s
//rs/private:semver_select_tests_test_4                         (cached) PASSED in 1.0s
//rs/private:semver_select_tests_test_5                         (cached) PASSED in 0.8s
//rs/private:semver_select_tests_test_6                         (cached) PASSED in 0.9s
//rs/private:semver_select_tests_test_7                         (cached) PASSED in 0.6s
//rs/private:semver_select_tests_test_8                         (cached) PASSED in 0.7s
//rs/private:semver_select_tests_test_9                         (cached) PASSED in 0.4s
//tools/rust_analyzer:gen_rust_project_lib_test                 (cached) PASSED in 1.1s

Executed 0 out of 39 tests: 39 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
- 