### PR TITLE
Support platform-specific crate annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,20 @@ Label attributes in `crate.annotation` are resolved in `MODULE.bazel`, so a rela
 
 See [`3rd_party/apriltag-sys/include.MODULE.bazel`](3rd_party/apriltag-sys/include.MODULE.bazel) for an example.
 
+Use `crate.annotation_select` to add dependencies, native link dependencies, or compatibility constraints only for selected target triples:
+
+```bzl
+crate.annotation_select(
+    crate = "example-sys",
+    deps = ["//native:shim"],
+    link_deps = ["@native_libs//:example"],
+    target_compatible_with = ["@platforms//os:linux"],
+    triples = ["x86_64-unknown-linux-gnu"],
+)
+```
+
+`remove_deps` and `remove_build_script_deps` on `crate.annotation` remove generated Cargo dependency edges by exact label. Use the hub name and versioned target emitted by `crate.from_cargo`, for example `@my_crates//:cc-1.2.0`. Removal applies only to generated dependencies; it does not remove dependencies added by the same annotation.
+
 </details>
 
 <details>
@@ -472,4 +486,3 @@ See https://registry.bazel.build/docs/rules_rs
 - [Aya](https://github.com/aya-rs/aya) and [bpf-linker](https://github.com/aya-rs/bpf-linker)
 - [Xybrid](https://github.com/xybrid-ai/xybrid)
 - [Drake](https://github.com/RobotLocomotion/drake)
-

--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -1,7 +1,7 @@
 load("@bazel_lib//lib:repo_utils.bzl", "repo_utils")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rs_rust_host_tools//:defs.bzl", "RS_HOST_CARGO_LABEL")
-load("//rs/private:annotations.bzl", "annotation_for", "build_annotation_map", "well_known_annotation_snippet_paths")
+load("//rs/private:annotations.bzl", "annotation_for", "apply_dependency_annotation", "build_annotation_map", "well_known_annotation_snippet_paths")
 load("//rs/private:cargo_credentials.bzl", "load_cargo_credentials")
 load(
     "//rs/private:cargo_workspace_graph.bzl",
@@ -295,6 +295,11 @@ def _generate_hub_and_spokes(
             snippet_path = suggested_annotation_snippet_paths.get(crate_name)
             if snippet_path:
                 suggested_annotation = mctx.read(snippet_path).strip()
+        deps_select = apply_dependency_annotation(
+            _select(feature_resolutions.deps),
+            annotation.deps_select,
+            annotation.remove_deps,
+        )
 
         if suggested_annotation:
             print("""
@@ -320,7 +325,10 @@ crate.annotation(
             hub_name = hub_name,
             gen_build_script = annotation.gen_build_script,
             build_script_deps = [],
-            build_script_deps_select = _select(feature_resolutions.build_deps),
+            build_script_deps_select = apply_dependency_annotation(
+                _select(feature_resolutions.build_deps),
+                removed_deps = annotation.remove_build_script_deps,
+            ),
             build_script_data = annotation.build_script_data,
             build_script_data_select = annotation.build_script_data_select,
             build_script_env = annotation.build_script_env,
@@ -336,8 +344,11 @@ crate.annotation(
             data = annotation.data,
             deps = annotation.deps,
             crate_tags = annotation.tags,
-            deps_select = _select(feature_resolutions.deps),
+            deps_select = deps_select,
             link_deps = annotation.link_deps,
+            link_deps_select = annotation.link_deps_select,
+            target_compatible_with = annotation.target_compatible_with,
+            target_compatible_with_select = annotation.target_compatible_with_select,
             aliases = feature_resolutions.aliases,
             crate_features = annotation.crate_features,
             crate_features_select = _select(feature_resolutions.features_enabled),
@@ -935,8 +946,17 @@ _ANNOTATION_SELECTABLE_ATTRS = {
     "crate_features": attr.string_list(
         doc = "Features to add to a crate's `rust_library::crate_features` attribute.",
     ),
+    "deps": attr.label_list(
+        doc = "Dependencies to add to a crate's `rust_library::deps` attribute.",
+    ),
+    "link_deps": attr.label_list(
+        doc = "Native dependencies to add to a crate's `rust_library::link_deps` attribute.",
+    ),
     "rustc_flags": attr.string_list(
         doc = "Flags to add to a crate's `rust_library::rustc_flags` attribute.",
+    ),
+    "target_compatible_with": attr.label_list(
+        doc = "Constraints to add to a crate's `target_compatible_with` attribute.",
     ),
 }
 
@@ -1001,6 +1021,12 @@ _annotation = tag_class(
         ),
         "link_deps": attr.string_list(
             doc = "Labels to add to a crate's `rust_library::link_deps` attribute.",
+        ),
+        "remove_deps": attr.string_list(
+            doc = "Exact dependency labels to remove from a crate's generated `rust_library::deps` attribute.",
+        ),
+        "remove_build_script_deps": attr.string_list(
+            doc = "Exact dependency labels to remove from a crate's generated `cargo_build_script::deps` attribute.",
         ),
         "tags": attr.string_list(
             doc = "A list of tags to add to a crate's generated targets.",

--- a/rs/private/BUILD.bazel
+++ b/rs/private/BUILD.bazel
@@ -10,6 +10,7 @@ load(":cargo_workspace_graph_test.bzl", "cargo_workspace_graph_tests")
 load(":cfg_parser_test.bzl", "cfg_parser_tests")
 load(":lint_flags_test.bzl", "lint_flags_tests")
 load(":registry_utils_test.bzl", "registry_utils_tests")
+load(":repository_utils_test.bzl", "repository_utils_tests")
 load(":rust_repository_utils_test.bzl", "rust_repository_utils_tests")
 load(":semver_test.bzl", "semver_select_tests")
 
@@ -42,6 +43,8 @@ cfg_parser_tests()
 lint_flags_tests()
 
 registry_utils_tests()
+
+repository_utils_tests()
 
 rust_repository_utils_tests()
 
@@ -198,6 +201,15 @@ bzl_library(
         ":cargo_toml_utils",
         ":select_utils",
         ":semver",
+    ],
+)
+
+bzl_library(
+    name = "repository_utils_test",
+    srcs = ["repository_utils_test.bzl"],
+    deps = [
+        ":repository_utils",
+        "@bazel_skylib//lib:unittest",
     ],
 )
 

--- a/rs/private/annotations.bzl
+++ b/rs/private/annotations.bzl
@@ -16,7 +16,13 @@ def _crate_annotation(
         build_script_tags = [],
         data = [],
         deps = [],
+        deps_select = {},
         link_deps = [],
+        link_deps_select = {},
+        remove_deps = [],
+        remove_build_script_deps = [],
+        target_compatible_with = [],
+        target_compatible_with_select = {},
         tags = [],
         crate_features = [],
         crate_features_select = {},
@@ -45,7 +51,13 @@ def _crate_annotation(
         build_script_tags = build_script_tags,
         data = data,
         deps = deps,
+        deps_select = deps_select,
         link_deps = link_deps,
+        link_deps_select = link_deps_select,
+        remove_deps = remove_deps,
+        remove_build_script_deps = remove_build_script_deps,
+        target_compatible_with = target_compatible_with,
+        target_compatible_with_select = target_compatible_with_select,
         tags = tags,
         crate_features = crate_features,
         crate_features_select = crate_features_select,
@@ -61,6 +73,25 @@ def _crate_annotation(
     )
 
 _DEFAULT_CRATE_ANNOTATION = _crate_annotation()
+
+def apply_dependency_annotation(generated_deps_select, added_deps_select = {}, removed_deps = []):
+    """Applies dependency additions and removals to generated per-platform dependencies.
+
+    Args:
+        generated_deps_select: Generated dependency labels keyed by platform triple.
+        added_deps_select: Additional dependency labels keyed by platform triple.
+        removed_deps: Exact generated dependency labels to remove from every triple.
+
+    Returns:
+        A new dependency map. The input maps and their lists are not mutated.
+    """
+    deps_select = {
+        triple: [dep for dep in deps if dep not in removed_deps]
+        for triple, deps in generated_deps_select.items()
+    }
+    for triple, deps in added_deps_select.items():
+        deps_select[triple] = deps_select.get(triple, []) + deps
+    return deps_select
 
 _WINDOWS_GNULLVM_ADDITIVE_BUILD_FILE_CONTENT = """
 load("@rules_cc//cc:defs.bzl", "cc_import")
@@ -124,7 +155,10 @@ _SELECTABLE_ANNOTATION_FIELDS = {
     "build_script_env": "build_script_env_select",
     "build_script_tools": "build_script_tools_select",
     "crate_features": "crate_features_select",
+    "deps": "deps_select",
+    "link_deps": "link_deps_select",
     "rustc_flags": "rustc_flags_select",
+    "target_compatible_with": "target_compatible_with_select",
 }
 
 _LIST_SELECT_FIELDS = [

--- a/rs/private/annotations_test.bzl
+++ b/rs/private/annotations_test.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load(":annotations.bzl", "annotation_for", "build_annotation_map")
+load(":annotations.bzl", "annotation_for", "apply_dependency_annotation", "build_annotation_map")
 
 _TRIPLES = [
     "aarch64-apple-darwin",
@@ -34,9 +34,12 @@ _ANNOTATION_DEFAULTS = {
     "patch_args": [],
     "patch_tool": "",
     "patches": [],
+    "remove_build_script_deps": [],
+    "remove_deps": [],
     "rustc_flags": [],
     "strip_prefix": "",
     "tags": [],
+    "target_compatible_with": [],
     "workspace_cargo_toml": "Cargo.toml",
 }
 
@@ -45,7 +48,10 @@ _ANNOTATION_SELECT_DEFAULTS = {
     "build_script_env": {},
     "build_script_tools": [],
     "crate_features": [],
+    "deps": [],
+    "link_deps": [],
     "rustc_flags": [],
+    "target_compatible_with": [],
 }
 
 def _annotation(crate, version = "*", **kwargs):
@@ -111,14 +117,20 @@ def _wildcard_and_exact_select_payloads_compose_impl(ctx):
                     "example",
                     ["x86_64-unknown-linux-gnu"],
                     build_script_env = {"COMMON": "wildcard", "OVERRIDE": "wildcard"},
+                    deps = ["//:wildcard_dep"],
+                    link_deps = ["//:wildcard_link_dep"],
                     rustc_flags = ["--cfg=wildcard"],
+                    target_compatible_with = ["//:wildcard_constraint"],
                 ),
                 _annotation_select(
                     "example",
                     ["x86_64-unknown-linux-gnu"],
                     version = "1.0.0",
                     build_script_env = {"EXACT": "exact", "OVERRIDE": "exact"},
+                    deps = ["//:exact_dep"],
+                    link_deps = ["//:exact_link_dep"],
                     rustc_flags = ["--cfg=exact"],
+                    target_compatible_with = ["//:exact_constraint"],
                 ),
             ],
         ),
@@ -136,6 +148,18 @@ def _wildcard_and_exact_select_payloads_compose_impl(ctx):
         "aarch64-apple-darwin": [],
         "x86_64-unknown-linux-gnu": ["--cfg=wildcard", "--cfg=exact"],
     }, annotation.rustc_flags_select)
+    asserts.equals(env, {
+        "aarch64-apple-darwin": [],
+        "x86_64-unknown-linux-gnu": ["//:wildcard_dep", "//:exact_dep"],
+    }, annotation.deps_select)
+    asserts.equals(env, {
+        "aarch64-apple-darwin": [],
+        "x86_64-unknown-linux-gnu": ["//:wildcard_link_dep", "//:exact_link_dep"],
+    }, annotation.link_deps_select)
+    asserts.equals(env, {
+        "aarch64-apple-darwin": [],
+        "x86_64-unknown-linux-gnu": ["//:wildcard_constraint", "//:exact_constraint"],
+    }, annotation.target_compatible_with_select)
 
     return unittest.end(env)
 
@@ -198,10 +222,33 @@ def _selected_windows_gnullvm_annotation_keeps_implicit_values_impl(ctx):
 
     return unittest.end(env)
 
+def _apply_dependency_annotation_removes_generated_and_adds_selected_impl(ctx):
+    env = unittest.begin(ctx)
+    deps_select = apply_dependency_annotation(
+        {
+            "aarch64-apple-darwin": ["@repo//:common", "@repo//:macos_only"],
+            "x86_64-unknown-linux-gnu": ["@repo//:common", "@repo//:linux_only"],
+        },
+        {
+            "x86_64-unknown-linux-gnu": ["//:replacement"],
+            "x86_64-pc-windows-msvc": ["//:windows_only"],
+        },
+        ["@repo//:common", "@repo//:linux_only"],
+    )
+
+    asserts.equals(env, {
+        "aarch64-apple-darwin": ["@repo//:macos_only"],
+        "x86_64-pc-windows-msvc": ["//:windows_only"],
+        "x86_64-unknown-linux-gnu": ["//:replacement"],
+    }, deps_select)
+
+    return unittest.end(env)
+
 exact_annotation_replaces_wildcard_and_composes_with_select_test = unittest.make(_exact_annotation_replaces_wildcard_and_composes_with_select_impl)
 wildcard_and_exact_select_payloads_compose_test = unittest.make(_wildcard_and_exact_select_payloads_compose_impl)
 wildcard_select_composes_with_exact_annotation_test = unittest.make(_wildcard_select_composes_with_exact_annotation_impl)
 selected_windows_gnullvm_annotation_keeps_implicit_values_test = unittest.make(_selected_windows_gnullvm_annotation_keeps_implicit_values_impl)
+apply_dependency_annotation_removes_generated_and_adds_selected_test = unittest.make(_apply_dependency_annotation_removes_generated_and_adds_selected_impl)
 
 def annotations_tests():
     return unittest.suite(
@@ -210,4 +257,5 @@ def annotations_tests():
         wildcard_and_exact_select_payloads_compose_test,
         wildcard_select_composes_with_exact_annotation_test,
         selected_windows_gnullvm_annotation_keeps_implicit_values_test,
+        apply_dependency_annotation_removes_generated_and_adds_selected_test,
     )

--- a/rs/private/repository_utils.bzl
+++ b/rs/private/repository_utils.bzl
@@ -178,7 +178,7 @@ _RUST_CRATE_MACRO_CALL = """{indent}rust_crate(
 {indent}    ]{extra_deps}{conditional_deps},
 {indent}    link_deps = [
 {indent}        {link_deps}
-{indent}    ],
+{indent}    ]{conditional_link_deps},
 {indent}    data = [
 {indent}        {data}
 {indent}    ],
@@ -189,7 +189,7 @@ _RUST_CRATE_MACRO_CALL = """{indent}rust_crate(
 {indent}    edition = {edition},
 {rustc_env_attr}{indent}    rustc_flags = {rustc_flags}{conditional_rustc_flags},
 {indent}    tags = {tags},
-{indent}    target_compatible_with = RESOLVED_PLATFORMS,
+{indent}    target_compatible_with = RESOLVED_PLATFORMS + {target_compatible_with}{conditional_target_compatible_with},
 {indent}    links = {links},
 {indent}    build_script = {build_script},
 {indent}    build_script_data = {build_script_data}{conditional_build_script_data},
@@ -222,8 +222,9 @@ def render_rust_crate_call(attr, values, bazel_metadata = {}, extra_deps = "", i
     build_script_tools, conditional_build_script_tools = render_select(attr.build_script_tools, attr.build_script_tools_select, use_legacy_rules_rust_platforms)
     rustc_flags, conditional_rustc_flags = render_select(attr.rustc_flags, attr.rustc_flags_select, use_legacy_rules_rust_platforms)
     deps, conditional_deps = render_select(attr.deps + bazel_metadata.get("deps", []), attr.deps_select, use_legacy_rules_rust_platforms)
+    link_deps, conditional_link_deps = render_select(getattr(attr, "link_deps", []), getattr(attr, "link_deps_select", {}), use_legacy_rules_rust_platforms)
+    target_compatible_with, conditional_target_compatible_with = render_select(getattr(attr, "target_compatible_with", []), getattr(attr, "target_compatible_with_select", {}), use_legacy_rules_rust_platforms)
     build_script_env_files = getattr(attr, "build_script_env_files", []) + ["cargo_toml_env_vars.env"]
-    link_deps = getattr(attr, "link_deps", [])
 
     conditional_build_script_env = render_select_build_script_env(attr.build_script_env_select, use_legacy_rules_rust_platforms)
 
@@ -255,6 +256,7 @@ def render_rust_crate_call(attr, values, bazel_metadata = {}, extra_deps = "", i
         extra_deps = extra_deps,
         conditional_deps = " + " + conditional_deps if conditional_deps else "",
         link_deps = list_indent.join(['"%s"' % d for d in sorted(link_deps)]),
+        conditional_link_deps = " + " + conditional_link_deps if conditional_link_deps else "",
         data = list_indent.join(['"%s"' % str(d) for d in attr.data]),
         extra_compile_data_attr = extra_compile_data_attr,
         crate_features = repr(sorted(crate_features)),
@@ -266,6 +268,8 @@ def render_rust_crate_call(attr, values, bazel_metadata = {}, extra_deps = "", i
         rustc_flags = repr(rustc_flags),
         conditional_rustc_flags = " + " + conditional_rustc_flags if conditional_rustc_flags else "",
         tags = repr(attr.crate_tags),
+        target_compatible_with = repr(sorted(target_compatible_with)),
+        conditional_target_compatible_with = " + " + conditional_target_compatible_with if conditional_target_compatible_with else "",
         links = values["links"],
         build_script = values["build_script"],
         build_script_data = repr(build_script_data),
@@ -327,7 +331,10 @@ rust_crate_attrs = {
     "data": attr.label_list(),
     "deps": attr.label_list(),
     "deps_select": _label_list_dict(),
-    "link_deps": attr.string_list(),
+    "link_deps": attr.label_list(),
+    "link_deps_select": _label_list_dict(),
+    "target_compatible_with": attr.label_list(),
+    "target_compatible_with_select": _label_list_dict(),
     "aliases": attr.string_dict(),
     "crate_features": attr.string_list(),
     "crate_features_select": attr.string_list_dict(),

--- a/rs/private/repository_utils_test.bzl
+++ b/rs/private/repository_utils_test.bzl
@@ -1,0 +1,97 @@
+"""Tests for generated crate repository BUILD rendering."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":repository_utils.bzl", "render_rust_crate_call")
+
+def _attr(**kwargs):
+    values = {
+        "aliases": {},
+        "allow_build_script_to_detect_nonhermetic_paths": False,
+        "build_script_data": [],
+        "build_script_data_select": {},
+        "build_script_deps": [],
+        "build_script_deps_select": {},
+        "build_script_env": {},
+        "build_script_env_files": [],
+        "build_script_env_select": {},
+        "build_script_tags": [],
+        "build_script_toolchains": [],
+        "build_script_tools": [],
+        "build_script_tools_select": {},
+        "crate_features": [],
+        "crate_features_select": {},
+        "crate_tags": [],
+        "data": [],
+        "deps": [],
+        "deps_select": {},
+        "rustc_flags": [],
+        "rustc_flags_select": {},
+        "use_legacy_rules_rust_platforms": False,
+    }
+    values.update(kwargs)
+    return struct(**values)
+
+def _values():
+    return {
+        "binaries": "{}",
+        "build_script": "None",
+        "crate_name": '"example"',
+        "crate_root": '"src/lib.rs"',
+        "edition": '"2021"',
+        "has_lib": "True",
+        "is_proc_macro": "False",
+        "links": "None",
+        "name": '"example-1.0.0"',
+        "purl": '"pkg:cargo/example@1.0.0"',
+        "version": '"1.0.0"',
+    }
+
+def _render_selectable_link_deps_and_compatibility_impl(ctx):
+    env = unittest.begin(ctx)
+    rendered = render_rust_crate_call(
+        _attr(
+            link_deps = ["//:base_link"],
+            link_deps_select = {
+                "aarch64-apple-darwin": ["//:macos_link"],
+                "x86_64-unknown-linux-gnu": [],
+            },
+            target_compatible_with = ["//:base_constraint"],
+            target_compatible_with_select = {
+                "aarch64-apple-darwin": [],
+                "x86_64-unknown-linux-gnu": ["//:linux_constraint"],
+            },
+        ),
+        _values(),
+    )
+
+    asserts.true(env, """link_deps = [
+        "//:base_link"
+    ] + select({
+        "@rules_rs//rs/platforms/config:aarch64-apple-darwin": ["//:macos_link"],
+        "//conditions:default": [],
+    }),""" in rendered)
+    asserts.true(env, """target_compatible_with = RESOLVED_PLATFORMS + ["//:base_constraint"] + select({
+        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": ["//:linux_constraint"],
+        "//conditions:default": [],
+    }),""" in rendered)
+
+    return unittest.end(env)
+
+def _render_missing_optional_fields_impl(ctx):
+    env = unittest.begin(ctx)
+    rendered = render_rust_crate_call(_attr(), _values())
+
+    asserts.true(env, "target_compatible_with = RESOLVED_PLATFORMS + []," in rendered)
+    asserts.true(env, "link_deps = [\n        \n    ]," in rendered)
+
+    return unittest.end(env)
+
+render_selectable_link_deps_and_compatibility_test = unittest.make(_render_selectable_link_deps_and_compatibility_impl)
+render_missing_optional_fields_test = unittest.make(_render_missing_optional_fields_impl)
+
+def repository_utils_tests():
+    return unittest.suite(
+        "repository_utils_tests",
+        render_selectable_link_deps_and_compatibility_test,
+        render_missing_optional_fields_test,
+    )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -39,6 +39,18 @@ cc_library(
     srcs = ["rustdoc_musl_unwind.cc"],
 )
 
+cc_library(
+    name = "annotation_select_native_dep",
+    srcs = ["annotation_select_native_dep.cc"],
+    visibility = ["//visibility:public"],
+)
+
+rust_library(
+    name = "annotation_select_rust_dep",
+    srcs = ["annotation_select_rust_dep.rs"],
+    visibility = ["//visibility:public"],
+)
+
 rust_library(
     name = "rustdoc_musl_unwind",
     srcs = ["rustdoc_musl_unwind.rs"],
@@ -164,6 +176,52 @@ genquery(
     name = "cfg_feature_target_dep_inner_deps",
     expression = "deps(@cfg_feature_target_dep//:inner-0.1.0)",
     scope = ["@cfg_feature_target_dep//:inner-0.1.0"],
+)
+
+genquery(
+    name = "annotation_select_deps",
+    expression = "deps(@build_script_env_select//:bitflags-2.9.4)",
+    scope = ["@build_script_env_select//:bitflags-2.9.4"],
+)
+
+genquery(
+    name = "annotation_build_dependency_removal_deps",
+    expression = "deps(@annotation_dependency_removals//:wasmtime-internal-jit-debug-37.0.0)",
+    scope = ["@annotation_dependency_removals//:wasmtime-internal-jit-debug-37.0.0"],
+)
+
+genquery(
+    name = "annotation_normal_dependency_removal_deps",
+    expression = "deps(@annotation_dependency_removals//:proc-macro2-1.0.101)",
+    scope = ["@annotation_dependency_removals//:proc-macro2-1.0.101"],
+)
+
+genrule(
+    name = "verify_annotation_platform_controls",
+    srcs = [
+        ":annotation_build_dependency_removal_deps",
+        ":annotation_normal_dependency_removal_deps",
+        ":annotation_select_deps",
+    ],
+    outs = ["verify_annotation_platform_controls.txt"],
+    cmd = """
+        grep 'annotation_select_rust_dep' $(location :annotation_select_deps)
+        grep 'annotation_select_native_dep' $(location :annotation_select_deps)
+        grep 'platforms.*os:linux' $(location :annotation_select_deps)
+        if grep -q 'unicode-ident-1.0.12' $(location :annotation_normal_dependency_removal_deps); then
+            echo 'remove_deps did not remove unicode-ident' >&2
+            exit 1
+        fi
+        if grep -q 'cc-1.2.38' $(location :annotation_build_dependency_removal_deps); then
+            echo 'remove_build_script_deps did not remove cc' >&2
+            exit 1
+        fi
+        echo ok > $@
+    """,
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 genrule(
@@ -369,6 +427,7 @@ filegroup(
     ] + select({
         "@platforms//os:windows": [],
         "//conditions:default": [
+            ":verify_annotation_platform_controls",
             ":verify_annotation_tags",
             ":verify_cfg_feature_target_dep",
             ":verify_first_party_feature_propagation",

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -161,6 +161,22 @@ TESTS = [
 
 [use_repo(crate, test) for test in TESTS]
 
+crate.from_cargo(
+    name = "annotation_dependency_removals",
+    cargo_lock = "//:build_script_aliases/Cargo.lock",
+    cargo_toml = "//:build_script_aliases/Cargo.toml",
+    debug = True,
+    platform_triples = [
+        "aarch64-unknown-linux-gnu",
+        "aarch64-apple-darwin",
+        "aarch64-pc-windows-gnullvm",
+        "x86_64-unknown-linux-gnu",
+        "x86_64-apple-darwin",
+        "x86_64-pc-windows-gnullvm",
+    ],
+)
+use_repo(crate, "annotation_dependency_removals")
+
 # Workspace member whose Cargo.toml lives at the bazel workspace root.
 crate.from_cargo(
     name = "root_package",
@@ -204,14 +220,27 @@ crate.annotation_select(
     build_script_data = ["//:dummy_test.sh"],
     build_script_tools = ["//:dummy_test.sh"],
     crate = "bitflags",
+    link_deps = ["//:annotation_select_native_dep"],
     repositories = ["build_script_env_select"],
+    target_compatible_with = ["@platforms//os:linux"],
     triples = ["x86_64-unknown-linux-gnu"],
+    deps = ["//:annotation_select_rust_dep"],
 )
 crate.annotation_select(
     build_script_env = {"OS": "linux"},
     crate = "bitflags",
     repositories = ["build_script_env_select"],
     triples = ["x86_64-unknown-linux-musl"],
+)
+crate.annotation(
+    crate = "wasmtime-internal-jit-debug",
+    remove_build_script_deps = ["@annotation_dependency_removals//:cc-1.2.38"],
+    repositories = ["annotation_dependency_removals"],
+)
+crate.annotation(
+    crate = "proc-macro2",
+    remove_deps = ["@annotation_dependency_removals//:unicode-ident-1.0.12"],
+    repositories = ["annotation_dependency_removals"],
 )
 crate.annotation(
     crate = "tokenizers",

--- a/test/annotation_select_native_dep.cc
+++ b/test/annotation_select_native_dep.cc
@@ -1,0 +1,1 @@
+void annotation_select_native_dep() {}

--- a/test/annotation_select_rust_dep.rs
+++ b/test/annotation_select_rust_dep.rs
@@ -1,0 +1,1 @@
+pub fn annotation_select_rust_dep() {}


### PR DESCRIPTION
## Summary

- add platform-selectable `deps`, `link_deps`, and `target_compatible_with` to crate annotations
- resolve native `link_deps` as labels in the module that declares the annotation
- allow exact removal of generated normal and build-script dependencies
- preserve rustc-source repository compatibility and document the new controls
- add focused unit coverage plus generated-repository integration tests for selected and removed dependencies

## Why

Cargo metadata sometimes needs Bazel-specific platform corrections or dependency replacement without patching generated repositories. Label-typed native dependencies preserve repository identity when annotations are declared outside the generated crate repository.
