### PR TITLE
Drop the stale openssl-sys `data` annotation

### DIFF
--- a/3rd_party/openssl-sys/include.MODULE.bazel
+++ b/3rd_party/openssl-sys/include.MODULE.bazel
@@ -11,7 +11,6 @@ crate.annotation(
         "OPENSSL_STATIC": "1",
     },
     crate = "openssl-sys",
-    data = ["@openssl//:gen_dir"],
     gen_build_script = "on",
 )
 


### PR DESCRIPTION
`data` on a crate annotation lands on the openssl-sys `rust_library`, where it can only reach two places: dependents' rustc inputs, through the legacy "fold data into compile inputs" behaviour, and runfiles.

The legacy paths are both off by default now -
`incompatible_do_not_include_data_in_compile_data` and `incompatible_do_not_include_transitive_data_in_compile_inputs` default to True in rules_rust 0.73.0 - so all this entry still does is copy `@openssl//:install`, a 32MB tree of static libs, headers, C sources and `bin/openssl`, into the runfiles of every target that transitively depends on openssl-sys. `OPENSSL_STATIC = 1` means nothing needs openssl at runtime, so those runfiles are never read.

It was not always dead weight: it arrived with ad42b793c, when the legacy default was what declared libssl.a and libcrypto.a into dependents' link inputs.

Removing it costs no hermeticity, because the annotation no longer provides any. The build script emits
`-Lnative=${pwd}/bazel-out/.../external/openssl+/install/lib` plus `-lstatic=ssl` and `-lstatic=crypto`, and nothing declares that tree as an input to the final link action either way - checked with `bazel aquery` on the Rustc action of a rust_test that links openssl, with and without this line. Those links only succeed under a spawn strategy that leaves the exec root visible; making them work under a hermetic sandbox or RBE needs a real link input, which is a separate change.