### PR TITLE
hotfix: refresh Linux zlib bootstrap pins

### DIFF
--- a/rs/private/rustc_repository.bzl
+++ b/rs/private/rustc_repository.bzl
@@ -54,13 +54,13 @@ filegroup(
 _LINUX_ZLIB = {
     "aarch64": struct(
         libdir = "usr/lib/aarch64-linux-gnu",
-        sha256 = "cbe3d39ec32d3cc27c021ae4af11e7c67bdf9d700d573207e0941d4038056278",
-        url = "https://ports.ubuntu.com/ubuntu-ports/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_arm64.deb",
+        sha256 = "e55ab3b4fb7b6edc4a628e28ec13f8780b08abe427d33ae148f030d8586d0e9a",
+        url = "https://ports.ubuntu.com/ubuntu-ports/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.2_arm64.deb",
     ),
     "x86_64": struct(
         libdir = "usr/lib/x86_64-linux-gnu",
-        sha256 = "7074b6a2f6367a10d280c00a1cb02e74277709180bab4f2491a2f355ab2d6c20",
-        url = "https://archive.ubuntu.com/ubuntu/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_amd64.deb",
+        sha256 = "84b9cf5752b29c9f92c27cd4c4ba9bbcc70b5ccf9b1b515421a28ae23212e273",
+        url = "https://archive.ubuntu.com/ubuntu/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.2_amd64.deb",
     ),
 }
 


### PR DESCRIPTION
Refresh the x86_64 and aarch64 Ubuntu zlib package URLs and SHA-256 values.

The existing `ubuntu2.1` artifacts return HTTP 404; both `ubuntu2.2` replacements were verified available and checksummed.

Closes #240.