### PR TITLE
feat: try first to download the source archive instead of using `git` for `github.com`

### DIFF
--- a/rs/private/git_cargo_workspace_repository.bzl
+++ b/rs/private/git_cargo_workspace_repository.bzl
@@ -60,8 +60,35 @@ crate(
         package_metadata_bazel_additive_build_file_content = cargo.bazel_metadata.get("additive_build_file_content", ""),
     ))
 
+_GITHUB_PREFIX = "https://github.com/"
+
+def _download_github_tarball(rctx):
+    """Downloads the crate sources from the GitHub archive.
+
+    Returns `False` when the caller must fall back to `git`.
+    """
+    repo_path = rctx.attr.remote.removeprefix(_GITHUB_PREFIX).removesuffix(".git")
+    rctx.download_and_extract(
+        url = "https://github.com/%s/archive/%s.tar.gz" % (repo_path, rctx.attr.commit),
+        type = "tar.gz",
+        stripPrefix = "%s-%s" % (repo_path.split("/")[-1], rctx.attr.commit),
+        canonical_id = "%s@%s" % (rctx.attr.remote, rctx.attr.commit),
+        # No checksum: GitHub does not promise a byte-stable archive. The commit pins the content.
+    )
+
+    # A GitHub archive holds no submodule.
+    if rctx.path(".gitmodules").exists:
+        rctx.report_progress("%s uses a submodule, falling back to git" % repo_path)
+        return False
+
+    return True
+
 def _git_cargo_workspace_repository_impl(rctx):
-    git_repo(rctx, rctx.path("."))
+    # The archive goes through the Bazel downloader. The downloader retries a failed request and it
+    # obeys `--downloader_config`. The `git` subprocess does neither. `git_repo` deletes the
+    # directory first, so it can still take over after the archive lands.
+    if not rctx.attr.remote.startswith(_GITHUB_PREFIX) or not _download_github_tarball(rctx):
+        git_repo(rctx, rctx.path("."))
 
     patch(rctx)
     rctx.delete(rctx.path(".git"))


### PR DESCRIPTION
This prevents anonymous fetch to be blocked especially in company networks when remote caches are down and the repo keeps being resolved:
```
Finished `release` profile [optimized] target(s) in 41.59s
  ERROR: error running 'git fetch origin refs/heads/*:refs/remotes/origin/* refs/tags/*:refs/tags/*' while working with @rules_rs++crate+frc__github.com_JetBrains_alacritty_41b81372:
  fatal: could not read Username for 'https://github.com': No such device or address
  fatal: expected flush after ref listing
  Process exited with code 8
  Process exited with code 8 (Step: bazel.cmd fetch  (Bazel))
  Step bazel.cmd fetch  (Bazel) failed
```