### PR TITLE
Add source-built zlib option for rustc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -59,6 +59,7 @@ bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.8")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_python", version = "1.6.3")
+bazel_dep(name = "zlib", version = "1.3.2")
 bazel_dep(name = "llvm", version = "0.8.18")
 
 osx = use_extension("@llvm//extensions:osx.bzl", "osx")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -254,8 +254,9 @@
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198",
+    "https://bcr.bazel.build/modules/zlib/1.3.2/MODULE.bazel": "7303cb87d80e438f313194fc640e38475a8d337b8c70ff6a0725f55236566a33",
+    "https://bcr.bazel.build/modules/zlib/1.3.2/source.json": "8f35ed65174ee2ad9630baeccd243cadf482b72d2ab32b57f9d84dc30ab076e0",
     "https://bcr.bazel.build/modules/zstd/1.5.7.bcr.1/MODULE.bazel": "c5977176dd8555be7a9d598512ae0cae11831259c06f00a5e5e0037d5db4e3f5",
     "https://bcr.bazel.build/modules/zstd/1.5.7.bcr.1/source.json": "aa95e0b5aac9d80195b9047d223beaf26b1948be55d49f0e803e180e9ccc6e75"
   },

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ bazel mod deps --lockfile_mode=update
 The second command restores the normal environment before the updated lockfile
 is committed.
 
+On Linux, rustc's bundled LLVM needs zlib at runtime. By default, the toolchain
+downloads a pinned Ubuntu package. Pass
+`--@rules_rs//rs/private:rustc_zlib_from_source=true` to build zlib from source
+using the Bazel Central Registry module instead. This is a global build flag and
+can also be set in `.bazelrc`.
+
 ### Global Cargo configuration
 
 The root module can configure a shared Cargo configuration file for every Cargo closure, including closures declared by dependencies:

--- a/rs/private/BUILD.bazel
+++ b/rs/private/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "bool_setting")
+load("@rules_cc//cc:defs.bzl", "cc_shared_library")
 load("@rules_rust//rust:rust_stdlib_filegroup.bzl", "rust_stdlib_filegroup")
 load(":all_crate_deps_test.bzl", "all_crate_deps_tests")
 load(":annotations_test.bzl", "annotations_tests")
@@ -19,9 +20,28 @@ bool_setting(
     visibility = ["//visibility:public"],
 )
 
+bool_flag(
+    name = "rustc_zlib_from_source",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "rustc_zlib_from_source_enabled",
+    flag_values = {":rustc_zlib_from_source": "true"},
+    visibility = ["//visibility:public"],
+)
+
 rust_stdlib_filegroup(
     name = "empty_stdlib",
     srcs = [],
+    visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "libz.so.1",
+    deps = ["@zlib//:z"],
+    shared_lib_name = "libz.so.1",
     visibility = ["//visibility:public"],
 )
 

--- a/rs/private/rustc_repository.bzl
+++ b/rs/private/rustc_repository.bzl
@@ -51,6 +51,19 @@ filegroup(
 )
 """
 
+_linux_zlib_build_file_tmpl = """\
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+
+copy_file(
+    name = "libz",
+    src = select({{
+        "@rules_rs//rs/private:rustc_zlib_from_source_enabled": "@rules_rs//rs/private:libz.so.1",
+        "//conditions:default": "@rustc_zlib_linux_{arch}//:libz.so.1",
+    }}),
+    out = "lib/libz.so.1",
+)
+"""
+
 _LINUX_ZLIB = {
     "aarch64": struct(
         libdir = "usr/lib/aarch64-linux-gnu",
@@ -80,12 +93,17 @@ def _extract_deb_payload(rctx, url, sha256, output, strip_prefix):
     rctx.extract(data_archive, output = output, stripPrefix = strip_prefix)
     rctx.delete(deb_dir)
 
-def _add_linux_zlib(rctx, exec_triple):
-    if exec_triple.system != "linux":
-        return
-
-    zlib = _LINUX_ZLIB[exec_triple.arch]
+def _rustc_zlib_repository_impl(rctx):
+    zlib = _LINUX_ZLIB[rctx.attr.arch]
     _extract_deb_payload(rctx, zlib.url, zlib.sha256, "lib", zlib.libdir)
+    rctx.file("BUILD.bazel", "exports_files([\"lib/libz.so.1\"], visibility = [\"//visibility:public\"])\n")
+
+rustc_zlib_repository = repository_rule(
+    implementation = _rustc_zlib_repository_impl,
+    attrs = {
+        "arch": attr.string(mandatory = True, values = _LINUX_ZLIB.keys()),
+    },
+)
 
 def _symlink_rust_objcopy_shared_libraries(rctx, exec_triple):
     top_level_lib = rctx.path("lib")
@@ -104,9 +122,9 @@ def _rustc_repository_impl(rctx):
     download_and_extract(rctx, "rustc", "rustc", exec_triple)
 
     # Upstream Linux rustc bundles libLLVM, which dynamically links against libz.so.1.
-    _add_linux_zlib(rctx, exec_triple)
+    build_content = _linux_zlib_build_file_tmpl.format(arch = exec_triple.arch) if exec_triple.system == "linux" else ""
     _symlink_rust_objcopy_shared_libraries(rctx, exec_triple)
-    build_content = _build_file_tmpl.format(
+    build_content += _build_file_tmpl.format(
         binary_ext = binary_ext,
         rustc_lib = rustc_lib_build_file(exec_triple),
         target_triple = exec_triple.str,

--- a/rs/toolchains/module_extension.bzl
+++ b/rs/toolchains/module_extension.bzl
@@ -18,7 +18,7 @@ load(
     "rust_redist_url_templates",
 )
 load("//rs/private:rust_src_repository.bzl", "rust_src_repository")
-load("//rs/private:rustc_repository.bzl", "rustc_repository")
+load("//rs/private:rustc_repository.bzl", "rustc_repository", "rustc_zlib_repository")
 load("//rs/private:rustc_src_repository.bzl", "rustc_src_repository")
 load("//rs/private:rustfmt_repository.bzl", "rustfmt_repository")
 load("//rs/private:stdlib_repository.bzl", "stdlib_repository")
@@ -377,6 +377,14 @@ def _toolchains_impl(mctx):
     host_arch = _normalize_arch_name(mctx.os.arch)
     host_cargo_repos = {}
     host_rustc_repos = {}
+
+    for triple in SUPPORTED_EXEC_TRIPLES:
+        exec_triple = _parse_triple(triple)
+        if exec_triple.system == "linux":
+            rustc_zlib_repository(
+                name = "rustc_zlib_linux_{}".format(exec_triple.arch),
+                arch = exec_triple.arch,
+            )
 
     for version in all_versions:
         version_key = sanitize_version(version)

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -2,6 +2,7 @@ load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@build_script_aliases//:data.bzl", build_script_aliases_dep_data = "DEP_DATA")
 load("@root_package//:defs.bzl", root_package_lint_config = "lint_config")
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_python//python:defs.bzl", "py_test")
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
@@ -25,6 +26,19 @@ sh_test(
     size = "medium",
     srcs = ["custom_registry_test.py"],
     local = True,
+)
+
+py_test(
+    name = "rustc_zlib_from_source_test",
+    size = "large",
+    srcs = ["rustc_zlib_from_source_test.py"],
+    env_inherit = ["PATH"],
+    local = True,
+    tags = ["external"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 sh_test(

--- a/test/rustc_zlib_from_source_test.py
+++ b/test/rustc_zlib_from_source_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Builds and runs a Rust binary with rustc's zlib built from source."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import pwd
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+class RustcZlibFromSourceTest(unittest.TestCase):
+    def test_rustc_runs_with_source_built_zlib(self) -> None:
+        bazel = shutil.which("bazel")
+        self.assertIsNotNone(bazel, "The zlib end-to-end test requires bazel on PATH")
+
+        rules_rs_root = pathlib.Path(__file__).resolve().parent.parent
+        bazel_environment = dict(os.environ)
+        bazel_environment.pop("TEST_TMPDIR", None)
+        bazel_environment["HOME"] = pwd.getpwuid(os.getuid()).pw_dir
+
+        with tempfile.TemporaryDirectory(prefix="rs-zlib-") as temporary_directory:
+            temporary_root = pathlib.Path(temporary_directory)
+            workspace = temporary_root / "workspace"
+            workspace.mkdir()
+            self._write_workspace(workspace, rules_rs_root)
+
+            result = subprocess.run(
+                [
+                    bazel,
+                    "--ignore_all_rc_files",
+                    "--batch",
+                    f"--output_base={temporary_root / 'bazel'}",
+                    "run",
+                    "--lockfile_mode=off",
+                    "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1",
+                    "--repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1",
+                    "--@rules_rs//rs/private:rustc_zlib_from_source=true",
+                    "//:hello",
+                ],
+                cwd=workspace,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=300,
+                env=bazel_environment,
+            )
+
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"Bazel run failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+            self.assertEqual(result.stdout.strip(), "zlib from source")
+
+    @staticmethod
+    def _write_workspace(workspace: pathlib.Path, rules_rs_root: pathlib.Path) -> None:
+        files = {
+            "MODULE.bazel": f"""\
+                module(name = "rustc_zlib_from_source_test")
+
+                bazel_dep(name = "llvm", version = "0.8.18")
+                bazel_dep(name = "rules_rs", version = "0.0.0")
+                local_path_override(
+                    module_name = "rules_rs",
+                    path = {str(rules_rs_root)!r},
+                )
+
+                toolchains = use_extension(
+                    "@rules_rs//rs/toolchains:module_extension.bzl",
+                    "toolchains",
+                )
+                use_repo(toolchains, "default_rust_toolchains")
+
+                register_toolchains(
+                    "@default_rust_toolchains//...",
+                    "@llvm//toolchain:all",
+                )
+                """,
+            "BUILD.bazel": """\
+                load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
+
+                rust_binary(
+                    name = "hello",
+                    srcs = ["main.rs"],
+                    edition = "2021",
+                )
+                """,
+            "main.rs": 'fn main() { println!("zlib from source"); }\n',
+        }
+        for name, content in files.items():
+            (workspace / name).write_text(textwrap.dedent(content))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Work toward #248. This does **not** fully fix the hermetic Linux rustc runtime yet.

Adds a global `--@rules_rs//rs/private:rustc_zlib_from_source=true` flag. On Linux, this builds `libz.so.1` from the BCR zlib module and places it alongside rustc's bundled LLVM runtime libraries.

The existing Ubuntu package path remains the default and has been moved into lazy architecture-specific repositories, so it is not fetched when source-built zlib is selected.

Adds a Linux E2E test that creates a downstream workspace, enables the flag, then builds and runs a Rust binary.

## Known limitation

Testing the same Rust compilation through the actiond Linux VM with remote fallback disabled exposed another missing runtime dependency before the zlib E2E could complete:

```text
rustc: error while loading shared libraries:
libgcc_s.so.1: cannot open shared object file
```

The source-built zlib path therefore does not by itself make the Linux rustc toolchain fully hermetic. `libgcc_s.so.1` also needs to be supplied before this should be considered a complete fix for #248.

## Testing

Passing locally:

- `bazel test //:rustc_zlib_from_source_test --test_output=errors` from `test/`
- `bazel build --//rs/private:rustc_zlib_from_source=true //tools/rust_analyzer:launcher` from the repository root

Remote actiond VM test:

- actiond built and started successfully
- the rules_rs build ran with remote fallback disabled, then failed because `libgcc_s.so.1` was unavailable