### PR TITLE
fix: update rules_rust and bundled zlib

### DIFF
--- a/rs/private/rustc_repository.bzl
+++ b/rs/private/rustc_repository.bzl
@@ -54,13 +54,13 @@ filegroup(
 _LINUX_ZLIB = {
     "aarch64": struct(
         libdir = "usr/lib/aarch64-linux-gnu",
-        sha256 = "cbe3d39ec32d3cc27c021ae4af11e7c67bdf9d700d573207e0941d4038056278",
-        url = "https://snapshot.ubuntu.com/ubuntu/20260801T000000Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_arm64.deb",
+        sha256 = "e55ab3b4fb7b6edc4a628e28ec13f8780b08abe427d33ae148f030d8586d0e9a",
+        url = "https://snapshot.ubuntu.com/ubuntu/20260901T000000Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.2_arm64.deb",
     ),
     "x86_64": struct(
         libdir = "usr/lib/x86_64-linux-gnu",
-        sha256 = "7074b6a2f6367a10d280c00a1cb02e74277709180bab4f2491a2f355ab2d6c20",
-        url = "https://snapshot.ubuntu.com/ubuntu/20260801T000000Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_amd64.deb",
+        sha256 = "84b9cf5752b29c9f92c27cd4c4ba9bbcc70b5ccf9b1b515421a28ae23212e273",
+        url = "https://snapshot.ubuntu.com/ubuntu/20260901T000000Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.2_amd64.deb",
     ),
 }
 

--- a/rs/rules_rust.bzl
+++ b/rs/rules_rust.bzl
@@ -31,9 +31,9 @@ def _rules_rust_impl(mctx):
 
     http_archive(
         name = "rules_rust",
-        integrity = "sha256-HlMDBHp6cs2qM2B6HiIXUctf4WG/qWKVhm3Kilsmyto=",
-        strip_prefix = "rules_rust-d11dcf615d6eddeb48d524d464563ca06c3b2a98",
-        url = "https://github.com/hermeticbuild/rules_rust/releases/download/source-d11dcf615d6eddeb48d524d464563ca06c3b2a98/rules_rust-d11dcf615d6eddeb48d524d464563ca06c3b2a98.tar.gz",
+        integrity = "sha256-s5EFeGy1titzc3DwMUI8d/HxoydztIMr7jeJ3pHVEzg=",
+        strip_prefix = "rules_rust-e9dd49f22cfa43c75ba30cd9d9bb7d8bdc459dde",
+        url = "https://github.com/hermeticbuild/rules_rust/releases/download/source-e9dd49f22cfa43c75ba30cd9d9bb7d8bdc459dde/rules_rust-e9dd49f22cfa43c75ba30cd9d9bb7d8bdc459dde.tar.gz",
         patches = patches,
         patch_strip = strip,
     )

--- a/test/target_triple_constraints_test.bzl
+++ b/test/target_triple_constraints_test.bzl
@@ -47,6 +47,8 @@ def target_triple_constraints_test(name = "target_triple_constraints_test"):
     rust_library(
         name = "target_triple_constraints_rust_library",
         srcs = ["target_triple_constraints_test.rs"],
+        # Analyze target-triple selection without compiling allocator libraries.
+        allocator_libraries = "@rules_rust//ffi/rs:empty_allocator_libraries",
         crate_name = "target_triple_constraints_test",
         tags = ["manual"],
     )


### PR DESCRIPTION
Update the rules_rust pin to source release e9dd49f22cfa43c75ba30cd9d9bb7d8bdc459dde, including the bootstrap reproducibility fix in hermeticbuild/rules_rust#53. Update bundled Ubuntu Noble zlib1g to 1.3.dfsg-3.1ubuntu2.2 for amd64 and arm64, retaining immutable snapshot URLs at 20260901T000000Z.

Select empty_allocator_libraries for target_triple_constraints_test. This test analyzes every target triple with an empty standard library and builds only a marker file; the new default allocator dependency otherwise requires a linker for these synthetic configurations.

Validation: all 48 root tests and target_triple_constraints_test passed on macOS with Bazel 9.1.0. Verified the source archive SHA-256 and bootstrap fix. Downloaded both zlib packages, matched their hashes against Ubuntu's snapshot package index, and checked the expected shared-library files. Buildifier and git diff --check pass.

Refs #243 and #233.

-zbarskybot