### PR TITLE
fix: disable BuildBuddy before BCR bazel info

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -8,8 +8,10 @@ bcr_test_module:
       name: "Run tests"
       platform: ${{ platform }}
       bazel: ${{ bazel }}
-      test_flags:
-        - "--experimental_remote_downloader="
+      shell_commands:
+        # bazelci runs bazel info before applying test_flags.
+        - |
+          printf '\ncommon --experimental_remote_downloader=\ncommon --remote_cache=\n' >> .bazelrc
       test_targets:
         - "//..."
 


### PR DESCRIPTION
BCR's v0.0.109 presubmit hit `PERMISSION_DENIED: Missing API key` while fetching `platforms` during `bazel info` ([failed job](https://buildkite.com/bazel/bcr-presubmit/builds/40799#01a07333-3974-4ac7-a0ce-e3462c20aa0b)). `bazelci` runs `bazel info` before applying `test_flags`, so the existing downloader override arrives too late. Move the downloader override and a remote-cache override into `shell_commands`, which appends them to `.bazelrc` before `bazel info`.

Validation: parsed the YAML, executed its exact shell command against the v0.0.109 archive, and ran Bazel 9.2.0 `info --announce_rc` successfully with both overrides confirmed. The release's original BCR jobs subsequently passed on retry and [BCR PR10408](https://github.com/bazelbuild/bazel-central-registry/pull/10408) merged; this change prevents recurrence in future releases.

-zbarskybot